### PR TITLE
fixed issue with switching from seg tab to previous

### DIFF
--- a/mpReview.py
+++ b/mpReview.py
@@ -1540,6 +1540,8 @@ class mpReviewWidget(ScriptedLoadableModuleWidget, ModuleWidgetMixin):
       if continueCurrentStep:
         self.tabWidget.setCurrentIndex(self.currentTabIndex)
         return True
+      else:
+        self.checkWhichDatabaseSelected()
     return False
 
   def onStep1Selected(self):


### PR DESCRIPTION
Before when switching from Segmentation tab to previous Study tab and segmentations were not saved, if you continued, the study/series list would not update properly with new selections. 

Now, added the self.checkWhichDatabaseSelected() in the checkStep2or3Leave() in order to reinit the studies list for selection.