### PR TITLE
Multiple server feature json hierarchy

### DIFF
--- a/Resources/mpReview_remote_gcp_configuration_hierarchy.json
+++ b/Resources/mpReview_remote_gcp_configuration_hierarchy.json
@@ -1,0 +1,28 @@
+{
+	"username": "deepa", 
+	"database_type": "remote",
+	"remote_database_configuration": 
+		{
+			"project_id":"idc-external-018",
+			"location_id":"us-central1",
+			"dataset_id":"pw39",
+			"dicomstore_id":"pw39", 
+			"other_server_url":""
+		},
+	"uids":
+		{
+			[
+				{
+					"StudyInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133"], 
+					"SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"] 
+				}, 
+				{
+					"StudyInstanceUID_list": [], 
+					"SeriesInstanceUID_list": []
+			] 
+		},
+	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
+	
+} 
+
+

--- a/Resources/mpReview_remote_gcp_configuration_hierarchy.json
+++ b/Resources/mpReview_remote_gcp_configuration_hierarchy.json
@@ -9,20 +9,17 @@
 			"dicomstore_id":"pw39", 
 			"other_server_url":""
 		},
-	"uids":
-		{
-			[
-				{
-					"StudyInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133"], 
-					"SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"] 
-				}, 
-				{
-					"StudyInstanceUID_list": [], 
-					"SeriesInstanceUID_list": []
-			] 
-		},
+
+    "uids":[
+        {
+            "StudyInstanceUID":"1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133",
+            "SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"]
+        },
+        {
+            "StudyInstanceUID":"1.3.6.1.4.1.14519.5.2.1.3671.4754.288848219213026850354055725664",
+            "SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.609837242670719860929372097937"]
+        }
+	],
 	"terminology": "C:/Users/deepa/git/mpReview/Resources/SegmentationCategoryTypeModifier-mpReview.json"
 	
 } 
-
-


### PR DESCRIPTION
Modified the code to instead have the study and series in a hierarchy in the json file, e.g.: 

```
    "uids":[
        {
            "StudyInstanceUID":"1.3.6.1.4.1.14519.5.2.1.3671.4754.121472087445374646718121301133",
            "SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.983460207615355998147518323000"]
        },
        {
            "StudyInstanceUID":"1.3.6.1.4.1.14519.5.2.1.3671.4754.288848219213026850354055725664",
            "SeriesInstanceUID_list": ["1.3.6.1.4.1.14519.5.2.1.3671.4754.609837242670719860929372097937"]
        }
	],
```

If the SeriesInstanceUID_list is "", or the series provided are invalid, then all series will be automatically loaded into the module. 

Refer to the new json, `mpReview_remote_gcp_configuration_hierarchy.json` file. 